### PR TITLE
Fix bug where classifications weren't sorted correctly

### DIFF
--- a/lib/salient/classifiers/bayes_classifier.js
+++ b/lib/salient/classifiers/bayes_classifier.js
@@ -120,7 +120,7 @@ BayesClassifier.prototype.getClassifications = function (observation) {
         labels.push({label: className, value: this.probabilityOfClass(observation, className) });
     }
 
-    return labels.sort(function (x, y) { return y.value > x.value });
+    return labels.sort(function (x, y) { return y.value - x.value });
 };
 
 BayesClassifier.restore = function (classifier) {


### PR DESCRIPTION
When I added 1K examples to a BayesClassifier, I wasn't getting the most relevant answer returning. I think this fixes it.
