### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/lib/salient/tokenizers/article_tokenizer.js
+++ b/lib/salient/tokenizers/article_tokenizer.js
@@ -3,7 +3,7 @@ var Tokenizer = require('./tokenizer');
 var RegExpTokenizer = require('./regexp_tokenizer');
 var WordPunctTokenizer = require('./wordpunct_tokenizer');
 var UrlTokenizer = require('./url_tokenizer');
-var ent = require('ent');
+var he = require('he');
 var util = require('util');
 var _ = require('underscore')._;
 
@@ -39,7 +39,7 @@ ArticleTokenizer.prototype._initializeTokenizers = function () {
     if (this.decodeURLEncoded) {
         // decode URL encoded characters
         this.cleanTokenizers.push(new RegExpTokenizer({
-            cleanPattern: /&amp;/ig, 
+            cleanPattern: /&amp;/ig,
             replaceWith: '&'
         }));
         this.cleanTokenizers.push(new RegExpTokenizer({
@@ -53,15 +53,15 @@ ArticleTokenizer.prototype._initializeTokenizers = function () {
     }
     if (this.cleanWikiMarkup) {
         this.cleanTokenizers.push(new RegExpTokenizer({
-            cleanPattern: /<ref[^<]*<\/ref>/ig, 
+            cleanPattern: /<ref[^<]*<\/ref>/ig,
             cleanTriggerChar: '<'
         }));
     }
     if (this.cleanXHTML) {
         // removes xhtml tags
-        this.cleanTokenizers.push(new RegExpTokenizer({ 
-            cleanPattern: /(<([^>]+)>)/ig, 
-            cleanTriggerChar: '<' 
+        this.cleanTokenizers.push(new RegExpTokenizer({
+            cleanPattern: /(<([^>]+)>)/ig,
+            cleanTriggerChar: '<'
         }));
     }
     if (this.cleanWikiMarkup) {
@@ -120,7 +120,7 @@ ArticleTokenizer.prototype._initializeTokenizers = function () {
 };
 
 /**
- * Tokenizes the given input 
+ * Tokenizes the given input
  */
 ArticleTokenizer.prototype.tokenize = function (s) {
     if (!s || s.length == 0)
@@ -164,7 +164,7 @@ ArticleTokenizer.prototype.clean = function (s) {
     if (!this.cleanTokenizers) {
         this._initializeTokenizers();
     }
-    s = ent.decode(s);
+    s = he.decode(s);
     for (var i = 0; i < this.cleanTokenizers.length; i++) {
         var cleanTokenizer = this.cleanTokenizers[i];
         s = cleanTokenizer.clean(s);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "underscore": "~1.5.2",
     "twitter-text": "~1.6.1",
-    "ent": "~0.1.0",
+    "he": "~0.5.0",
     "treetagger": "~0.1.1",
     "sylvester": "0.0.21",
     "readline": "0.0.3",


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](https://mths.be/he).
